### PR TITLE
added includes

### DIFF
--- a/src/libOL/Blocks/Block.h
+++ b/src/libOL/Blocks/Block.h
@@ -9,6 +9,10 @@
 #include <iostream>
 #include <vector>
 
+#ifdef __linux 
+#include <string.h>
+#endif 
+
 namespace libol {
     class Block {
     public:

--- a/src/libOL/Blocks/Block.h
+++ b/src/libOL/Blocks/Block.h
@@ -8,10 +8,7 @@
 #include <cassert>
 #include <iostream>
 #include <vector>
-
-#ifdef __linux 
-#include <string.h>
-#endif 
+#include <cstring>
 
 namespace libol {
     class Block {

--- a/src/libOL/Blowfish/Blowfish.cpp
+++ b/src/libOL/Blowfish/Blowfish.cpp
@@ -4,6 +4,7 @@
 #include "Blowfish.h"
 
 #include <memory>
+#include <stdexcept>
 
 extern "C" {
 #include <openssl/blowfish.h>
@@ -37,6 +38,10 @@ namespace libol {
         std::vector<uint8_t> rawDecrypt(std::vector<uint8_t> bytes, std::vector<uint8_t> key) {
                 return ::actuallyDoTheCrypto(bytes, key, false);
         }
+        
+        /**
+         * \throws std::invalid_argument if the padding is invalid
+         */
         std::vector<uint8_t> decrypt(std::vector<uint8_t> bytes, std::vector<uint8_t> key) {
                 auto data = rawDecrypt(bytes, key);
 

--- a/src/libOL/Blowfish/Blowfish.h
+++ b/src/libOL/Blowfish/Blowfish.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <stdexcept>
 
 namespace libol {
     namespace Blowfish {

--- a/src/libOL/Blowfish/Blowfish.h
+++ b/src/libOL/Blowfish/Blowfish.h
@@ -6,7 +6,6 @@
 
 #include <vector>
 #include <cstdint>
-#include <stdexcept>
 
 namespace libol {
     namespace Blowfish {


### PR DESCRIPTION
Compiling on linux with gcc 4.7.3 fails for me without these imports. I guess string.h might be a linux-only thing so I wrapped it to prevent errors on windows. stdexcept on the other hadn should be everywhere. 

This needs testing on other OS before getting pulled, thanks!
